### PR TITLE
Fix unreadable text in dark mode

### DIFF
--- a/barcelona-ibiza-trip/src/app/globals.css
+++ b/barcelona-ibiza-trip/src/app/globals.css
@@ -5,13 +5,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  color-scheme: light;
 }
 
 body {


### PR DESCRIPTION
## Summary
- keep light theme colors regardless of system dark mode

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a25fcec8548333b5d85b8501608075