### PR TITLE
Enable editing schedule items, fix photo links, and improve dialog readability

### DIFF
--- a/barcelona-ibiza-trip/src/components/ui/dialog.tsx
+++ b/barcelona-ibiza-trip/src/components/ui/dialog.tsx
@@ -12,7 +12,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/40", className)}
+    className={cn("fixed inset-0 z-50 bg-black/60 backdrop-blur-sm", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- allow editing schedule entries and persist updates to Supabase
- improve schedule card styling and polish
- fix photo URLs by encoding Supabase paths
- darken and blur dialog overlay while strengthening form labels for readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26daaf920833392e862e2eddcf9dd