### PR TITLE
Fix photo listing by adding server-side endpoint

### DIFF
--- a/barcelona-ibiza-trip/src/app/api/photos/route.ts
+++ b/barcelona-ibiza-trip/src/app/api/photos/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export async function GET() {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    return NextResponse.json(
+      { error: "Service role key not configured" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceKey
+  );
+
+  const { data: files, error } = await supabase.storage
+    .from("trip-photos")
+    .list("", { limit: 100 });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const photos =
+    files?.map(
+      (f) =>
+        supabase.storage.from("trip-photos").getPublicUrl(f.name).data
+          .publicUrl
+    ) ?? [];
+
+  return NextResponse.json({ photos });
+}

--- a/barcelona-ibiza-trip/src/components/TripApp.tsx
+++ b/barcelona-ibiza-trip/src/components/TripApp.tsx
@@ -209,17 +209,9 @@ export default function TripApp() {
         .from("flights")
         .select()
         .order("date");
-      const { data: files } = await supabase.storage
-        .from("trip-photos")
-        .list("", { limit: 100 });
-      const photos =
-        files?.map(
-          (f) =>
-            encodeURI(
-              supabase.storage.from("trip-photos").getPublicUrl(f.name).data
-                .publicUrl
-            )
-        ) ?? [];
+      const photos = await fetch("/api/photos")
+        .then((r) => (r.ok ? r.json() : { photos: [] }))
+        .then((r) => r.photos as string[]);
       setData((d) => ({
         ...d,
         schedule: (sched as ScheduleItem[]) || [],


### PR DESCRIPTION
## Summary
- add `/api/photos` route that lists trip photos using the Supabase service role key
- load photos via new API route in `TripApp`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2742c44d48333b0cf6320abdcdec1