### PR TITLE
Improve schedule edit form readability

### DIFF
--- a/barcelona-ibiza-trip/src/components/TripApp.tsx
+++ b/barcelona-ibiza-trip/src/components/TripApp.tsx
@@ -727,6 +727,7 @@ function AddScheduleDialog({
               type="time"
               value={time}
               onChange={(e) => setTime(e.target.value)}
+              step={300}
             />
           </Row>
           <Row label="Title">
@@ -850,6 +851,7 @@ function EditScheduleDialog({
               type="time"
               value={time}
               onChange={(e) => setTime(e.target.value)}
+              step={300}
             />
           </Row>
           <Row label="Title">

--- a/barcelona-ibiza-trip/src/components/ui/select.tsx
+++ b/barcelona-ibiza-trip/src/components/ui/select.tsx
@@ -34,7 +34,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        "relative z-[60] min-w-[8rem] overflow-hidden rounded-md border bg-background text-foreground shadow-md",
         className
       )}
       position={position}


### PR DESCRIPTION
## Summary
- fix obscured select menu in schedule dialog
- use 5-minute increments for schedule time inputs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a274718d9c8333b0ee956206f77939