### PR TITLE
Fix schedule dialog select visibility and add 5-minute time picker

### DIFF
--- a/barcelona-ibiza-trip/src/components/TripApp.tsx
+++ b/barcelona-ibiza-trip/src/components/TripApp.tsx
@@ -115,6 +115,18 @@ function uid(prefix = "id") {
   return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+const TIME_OPTIONS = Array.from({ length: 24 * 12 }, (_, i) => {
+  const h = Math.floor(i / 12);
+  const m = (i % 12) * 5;
+  const value = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  const label = `${String(hour12).padStart(2, "0")}:${String(m).padStart(
+    2,
+    "0"
+  )} ${h < 12 ? "AM" : "PM"}`;
+  return { value, label };
+});
+
 // ----------------------------
 // Default Data
 // ----------------------------
@@ -723,11 +735,22 @@ function AddScheduleDialog({
             />
           </Row>
           <Row label="Time">
-            <Input
-              type="time"
-              value={time}
-              onChange={(e) => setTime(e.target.value)}
-            />
+            <Select
+              value={time === "" ? "__none" : time}
+              onValueChange={(v) => setTime(v === "__none" ? "" : v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select time" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">No time</SelectItem>
+                {TIME_OPTIONS.map((t) => (
+                  <SelectItem key={t.value} value={t.value}>
+                    {t.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </Row>
           <Row label="Title">
             <Input
@@ -846,11 +869,22 @@ function EditScheduleDialog({
             />
           </Row>
           <Row label="Time">
-            <Input
-              type="time"
-              value={time}
-              onChange={(e) => setTime(e.target.value)}
-            />
+            <Select
+              value={time === "" ? "__none" : time}
+              onValueChange={(v) => setTime(v === "__none" ? "" : v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select time" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">No time</SelectItem>
+                {TIME_OPTIONS.map((t) => (
+                  <SelectItem key={t.value} value={t.value}>
+                    {t.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </Row>
           <Row label="Title">
             <Input

--- a/barcelona-ibiza-trip/src/components/ui/select.tsx
+++ b/barcelona-ibiza-trip/src/components/ui/select.tsx
@@ -34,7 +34,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        "relative z-[70] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
         className
       )}
       position={position}


### PR DESCRIPTION
## Summary
- ensure select menus render above dialog overlay with popover styling
- replace time input with select-based picker using 5-minute increments

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a274718d9c8333b0ee956206f77939