### PR TITLE
Filter out past events from schedule

### DIFF
--- a/barcelona-ibiza-trip/src/components/TripApp.tsx
+++ b/barcelona-ibiza-trip/src/components/TripApp.tsx
@@ -11,7 +11,7 @@ import { Switch } from "@/components/ui/switch";
 import { Calendar, ExternalLink, Home, MapPin, Plane, Image } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 import { TripData, ScheduleItem, Flight } from "@/types/trip";
-import { mapLink, formatTime, formatDT, byDateTime, groupByDate, uid } from "@/utils/trip-utils";
+import { mapLink, formatTime, formatDT, byDateTime, groupByDate, uid, isUpcoming } from "@/utils/trip-utils";
 import { SectionHeader, Badge } from "@/components/ui/SectionHeader";
 import { AddScheduleDialog } from "@/components/dialogs/AddScheduleDialog";
 import { EditScheduleDialog } from "@/components/dialogs/EditScheduleDialog";
@@ -91,8 +91,10 @@ export default function TripApp() {
   }, [data.flights]);
 
   const scheduleSorted = useMemo(() => {
-    // Combine actual schedule with virtual flight schedule items
-    const combined = [...data.schedule, ...flightScheduleItems].sort(byDateTime);
+    const now = new Date();
+    const combined = [...data.schedule, ...flightScheduleItems]
+      .filter((s) => isUpcoming(s, now))
+      .sort(byDateTime);
     return areaFilter === "All" ? combined : combined.filter((s) => s.area === areaFilter);
   }, [data.schedule, flightScheduleItems, areaFilter]);
 

--- a/barcelona-ibiza-trip/src/utils/trip-utils.ts
+++ b/barcelona-ibiza-trip/src/utils/trip-utils.ts
@@ -43,3 +43,15 @@ export function groupByDate(items: ScheduleItem[]) {
 export function uid(prefix = "id") {
   return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
 }
+
+export function isUpcoming(it: ScheduleItem, now: Date = new Date()) {
+  const today = now.toISOString().slice(0, 10);
+  if (it.date > today) return true;
+  if (it.date < today) return false;
+
+  if (!it.time) return true;
+  const [h, m] = it.time.split(":").map(Number);
+  const itemTime = new Date(now);
+  itemTime.setHours(h, m, 0, 0);
+  return itemTime >= now;
+}


### PR DESCRIPTION
## Summary
- add `isUpcoming` utility to check if schedule items occur today or later
- filter schedule to hide past events on app load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58a8ecf2c833398a2758be2e9d67a